### PR TITLE
do not truncate $vatNumber

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -70,7 +70,7 @@ class Validation
      * @return mixed
      */
     public function convertVatIdToVatNumber() {
-        $vatNumber = substr($this->vatId, 2, 11);
+        $vatNumber = substr($this->vatId, 2);
         return $vatNumber;
     }
 


### PR DESCRIPTION
Dutch VAT Numbers can be 12 characters long ex: NL851907568B01